### PR TITLE
G2P-409, 471 - Make text area input boxes wider and hide tooltip for mechanism

### DIFF
--- a/src/components/add-publication/UpdateMechanismEvidence.vue
+++ b/src/components/add-publication/UpdateMechanismEvidence.vue
@@ -425,28 +425,23 @@ export default {
                       </li>
                     </ul>
                   </div>
-                  <div class="row mt-2 w-50">
+                  <div class="mt-2">
                     <label
                       :for="`evidence-type-input-${pmid}-description`"
-                      class="col-form-label col-lg-3"
+                      class="form-label"
                     >
                       Description
                     </label>
-                    <div class="col-lg-9">
-                      <textarea
-                        class="form-control"
-                        :id="`evidence-type-input-${pmid}-description`"
-                        rows="3"
-                        :value="mechanismEvidence[pmid].description"
-                        @input="
-                          mechanismEvidenceInputHandler(
-                            pmid,
-                            $event.target.value
-                          )
-                        "
-                      >
-                      </textarea>
-                    </div>
+                    <textarea
+                      class="form-control"
+                      :id="`evidence-type-input-${pmid}-description`"
+                      rows="3"
+                      :value="mechanismEvidence[pmid].description"
+                      @input="
+                        mechanismEvidenceInputHandler(pmid, $event.target.value)
+                      "
+                    >
+                    </textarea>
                   </div>
                 </div>
               </div>

--- a/src/components/add-publication/UpdateMechanismEvidence.vue
+++ b/src/components/add-publication/UpdateMechanismEvidence.vue
@@ -5,8 +5,9 @@ import {
   MechanismAttribs,
   MechanismSupportAttribs,
   MechanismSynopsisAttribs,
-} from "../../utility/CurationConstants";
+} from "../../utility/CurationConstants.js";
 import kebabCase from "lodash/kebabCase";
+import { HELP_TEXT } from "../../utility/Constants.js";
 export default {
   props: {
     currentMechanism: Object,
@@ -52,6 +53,7 @@ export default {
       mechanismSynopsisAttribs: [...MechanismSynopsisAttribs],
       mechanismSupportAttribs: [...MechanismSupportAttribs],
       evidenceTypesAttribs: [...EvidenceTypesAttribs],
+      HELP_TEXT,
     };
   },
   computed: {
@@ -139,7 +141,8 @@ export default {
                 <label for="mechanism-input" class="col-form-label">
                   Mechanism
                   <ToolTip
-                    toolTipText="To change Mechanism, please contact Admin at g2p-help@ebi.ac.uk"
+                    v-if="!canUpdateMechanismInput"
+                    :toolTipText="HELP_TEXT.CHANGE_MECHANISM"
                   />
                 </label>
               </div>

--- a/src/components/add-publication/UpdatePhenotype.vue
+++ b/src/components/add-publication/UpdatePhenotype.vue
@@ -256,22 +256,20 @@ export default {
                     </div>
                   </div>
                 </div>
-                <div class="row mt-4 w-50">
+                <div class="mt-4">
                   <label
                     :for="`phenotype-summary-input-${pmid}`"
-                    class="col-form-label col-lg-3"
+                    class="form-label"
                   >
                     Summary
                   </label>
-                  <div class="col-lg-9">
-                    <textarea
-                      class="form-control"
-                      :id="`phenotype-summary-input-${pmid}`"
-                      rows="3"
-                      :value="clinicalPhenotype[pmid].summary"
-                      @input="summaryInputHandler(pmid, $event.target.value)"
-                    ></textarea>
-                  </div>
+                  <textarea
+                    class="form-control"
+                    :id="`phenotype-summary-input-${pmid}`"
+                    rows="3"
+                    :value="clinicalPhenotype[pmid].summary"
+                    @input="summaryInputHandler(pmid, $event.target.value)"
+                  ></textarea>
                 </div>
                 <div
                   class="row pt-3"

--- a/src/components/curation/ClinicalPhenotype.vue
+++ b/src/components/curation/ClinicalPhenotype.vue
@@ -168,22 +168,20 @@ export default {
                   </div>
                 </div>
               </div>
-              <div class="row mt-4 w-50">
+              <div class="mt-4">
                 <label
                   :for="`phenotype-summary-input-${pmid}`"
-                  class="col-form-label col-lg-3"
+                  class="form-label"
                 >
                   Summary
                 </label>
-                <div class="col-lg-9">
-                  <textarea
-                    class="form-control"
-                    :id="`phenotype-summary-input-${pmid}`"
-                    rows="3"
-                    :value="clinicalPhenotype[pmid].summary"
-                    @input="summaryInputHandler(pmid, $event.target.value)"
-                  ></textarea>
-                </div>
+                <textarea
+                  class="form-control"
+                  :id="`phenotype-summary-input-${pmid}`"
+                  rows="3"
+                  :value="clinicalPhenotype[pmid].summary"
+                  @input="summaryInputHandler(pmid, $event.target.value)"
+                ></textarea>
               </div>
               <div
                 class="row pt-3"

--- a/src/components/curation/Comment.vue
+++ b/src/components/curation/Comment.vue
@@ -8,36 +8,32 @@ export default {
 };
 </script>
 <template>
-  <div class="row py-3 w-50">
-    <label for="private-comment-input" class="col-lg-3 col-form-label">
+  <div class="py-3">
+    <label for="private-comment-input" class="form-label">
       Private comment
     </label>
-    <div class="col-lg-9">
-      <textarea
-        class="form-control"
-        id="private-comment-input"
-        rows="3"
-        type="text"
-        :value="privateComment"
-        @input="$emit('update:privateComment', $event.target.value)"
-      >
-      </textarea>
-    </div>
+    <textarea
+      class="form-control"
+      id="private-comment-input"
+      rows="3"
+      type="text"
+      :value="privateComment"
+      @input="$emit('update:privateComment', $event.target.value)"
+    >
+    </textarea>
   </div>
-  <div class="row pb-3 w-50">
-    <label for="public-comment-input" class="col-lg-3 col-form-label">
+  <div class="pb-3">
+    <label for="public-comment-input" class="form-label">
       Public comment
     </label>
-    <div class="col-lg-9">
-      <textarea
-        class="form-control"
-        id="public-comment-input"
-        rows="3"
-        type="text"
-        :value="publicComment"
-        @input="$emit('update:publicComment', $event.target.value)"
-      >
-      </textarea>
-    </div>
+    <textarea
+      class="form-control"
+      id="public-comment-input"
+      rows="3"
+      type="text"
+      :value="publicComment"
+      @input="$emit('update:publicComment', $event.target.value)"
+    >
+    </textarea>
   </div>
 </template>

--- a/src/components/curation/MechanismEvidence.vue
+++ b/src/components/curation/MechanismEvidence.vue
@@ -113,23 +113,21 @@ export default {
           </li>
         </ul>
       </div>
-      <div class="row mt-2 w-50">
+      <div class="mt-2">
         <label
           :for="`evidence-type-input-${pmid}-description`"
-          class="col-form-label col-lg-3"
+          class="form-label"
         >
           Description
         </label>
-        <div class="col-lg-9">
-          <textarea
-            class="form-control"
-            :id="`evidence-type-input-${pmid}-description`"
-            rows="3"
-            :value="mechanismEvidence[pmid].description"
-            @input="mechanismEvidenceInputHandler(pmid, $event.target.value)"
-          >
-          </textarea>
-        </div>
+        <textarea
+          class="form-control"
+          :id="`evidence-type-input-${pmid}-description`"
+          rows="3"
+          :value="mechanismEvidence[pmid].description"
+          @input="mechanismEvidenceInputHandler(pmid, $event.target.value)"
+        >
+        </textarea>
       </div>
     </div>
   </div>

--- a/src/components/update-record/AddComment.vue
+++ b/src/components/update-record/AddComment.vue
@@ -67,6 +67,7 @@ export default {
     <i class="bi bi-info-circle"></i> After updating data, use the form below to
     submit any additional comments.
   </p>
+  <hr />
   <h5>Comments</h5>
   <div
     class="d-flex justify-content-center"
@@ -78,35 +79,31 @@ export default {
     </div>
   </div>
   <div v-else>
-    <div class="row py-3 w-50">
-      <label for="private-comment-input" class="col-lg-3 col-form-label">
+    <div class="pb-3">
+      <label for="private-comment-input" class="form-label">
         Private comment
       </label>
-      <div class="col-lg-9">
-        <textarea
-          class="form-control"
-          id="private-comment-input"
-          rows="3"
-          type="text"
-          v-model="privateComment"
-        >
-        </textarea>
-      </div>
+      <textarea
+        class="form-control"
+        id="private-comment-input"
+        rows="3"
+        type="text"
+        v-model="privateComment"
+      >
+      </textarea>
     </div>
-    <div class="row pb-3 w-50">
-      <label for="public-comment-input" class="col-lg-3 col-form-label">
+    <div class="pb-3">
+      <label for="public-comment-input" class="form-label">
         Public comment
       </label>
-      <div class="col-lg-9">
-        <textarea
-          class="form-control"
-          id="public-comment-input"
-          rows="3"
-          type="text"
-          v-model="publicComment"
-        >
-        </textarea>
-      </div>
+      <textarea
+        class="form-control"
+        id="public-comment-input"
+        rows="3"
+        type="text"
+        v-model="publicComment"
+      >
+      </textarea>
     </div>
     <button type="button" class="btn btn-primary" @click="addComment">
       <i class="bi bi-pencil-square"></i> Submit comment

--- a/src/components/update-record/UpdateMechanism.vue
+++ b/src/components/update-record/UpdateMechanism.vue
@@ -557,22 +557,20 @@ export default {
                       </li>
                     </ul>
                   </div>
-                  <div class="row mt-2 w-50">
+                  <div class="mt-2">
                     <label
                       :for="`evidence-type-input-${pmid}-description`"
-                      class="col-form-label col-lg-3"
+                      class="form-label"
                     >
                       Description
                     </label>
-                    <div class="col-lg-9">
-                      <textarea
-                        class="form-control"
-                        :id="`evidence-type-input-${pmid}-description`"
-                        rows="3"
-                        v-model="mechanismEvidence[pmid].description"
-                      >
-                      </textarea>
-                    </div>
+                    <textarea
+                      class="form-control"
+                      :id="`evidence-type-input-${pmid}-description`"
+                      rows="3"
+                      v-model="mechanismEvidence[pmid].description"
+                    >
+                    </textarea>
                   </div>
                 </div>
               </div>

--- a/src/components/update-record/UpdateMechanism.vue
+++ b/src/components/update-record/UpdateMechanism.vue
@@ -11,7 +11,7 @@ import kebabCase from "lodash/kebabCase";
 import ToolTip from "../tooltip/ToolTip.vue";
 import { fetchAndLogApiResponseErrorMsg } from "../../utility/ErrorUtility.js";
 import api from "../../services/api.js";
-import { HELP_TEXT } from "@/utility/Constants.js";
+import { HELP_TEXT } from "../../utility/Constants.js";
 
 export default {
   props: {
@@ -292,7 +292,10 @@ export default {
                 <div class="col-lg-2">
                   <label for="mechanism-input" class="col-form-label">
                     Mechanism
-                    <ToolTip :toolTipText="HELP_TEXT.CHANGE_MECHANISM" />
+                    <ToolTip
+                      v-if="!canUpdateMechanismInput"
+                      :toolTipText="HELP_TEXT.CHANGE_MECHANISM"
+                    />
                   </label>
                 </div>
                 <div class="col-xl-3 col-lg-3 col-6">

--- a/src/components/update-record/UpdatePhenotype.vue
+++ b/src/components/update-record/UpdatePhenotype.vue
@@ -489,21 +489,19 @@ export default {
                       </div>
                     </div>
                   </div>
-                  <div class="row mt-4 w-50">
+                  <div class="mt-4">
                     <label
                       :for="`phenotype-summary-input-${pmid}`"
-                      class="col-form-label col-lg-3"
+                      class="form-label"
                     >
                       Summary
                     </label>
-                    <div class="col-lg-9">
-                      <textarea
-                        class="form-control"
-                        :id="`phenotype-summary-input-${pmid}`"
-                        rows="3"
-                        v-model="clinicalPhenotype[pmid].summary"
-                      ></textarea>
-                    </div>
+                    <textarea
+                      class="form-control"
+                      :id="`phenotype-summary-input-${pmid}`"
+                      rows="3"
+                      v-model="clinicalPhenotype[pmid].summary"
+                    ></textarea>
                   </div>
                   <div
                     class="row pt-3"


### PR DESCRIPTION
Code changes related to [G2P-471](https://www.ebi.ac.uk/panda/jira/browse/G2P-471) and [G2P-409](https://www.ebi.ac.uk/panda/jira/browse/G2P-409). Make text area input boxes wider and hide tooltip for mechanism input label for undetermined.