### PR TITLE
G2P-494 - Rename mechanism 'Evidence' section to 'Functional Studies'

### DIFF
--- a/src/components/add-publication/AddPublication.vue
+++ b/src/components/add-publication/AddPublication.vue
@@ -317,7 +317,7 @@ export default {
       </div>
       <p v-else>
         <i class="bi bi-info-circle"></i> Please enter Publication(s) and click
-        'Add' to proceed further.
+        <b>Add</b> to proceed further.
       </p>
     </div>
     <div

--- a/src/components/add-publication/UpdateMechanismEvidence.vue
+++ b/src/components/add-publication/UpdateMechanismEvidence.vue
@@ -335,7 +335,7 @@ export default {
                     <table class="table table-bordered mb-0">
                       <thead>
                         <tr>
-                          <th>Evidence Types</th>
+                          <th>Functional Studies</th>
                           <th>Publication</th>
                         </tr>
                       </thead>
@@ -379,7 +379,7 @@ export default {
             </div>
             <form>
               <div v-if="isDisplayNewEvidenceForm">
-                <h5 class="mb-0">Evidence for new Publication(s)</h5>
+                <h5 class="mb-0">Functional Studies for new Publication(s)</h5>
                 <div
                   class="py-3"
                   v-for="pmid in Object.keys(mechanismEvidence)"

--- a/src/components/curation/MechanismEvidence.vue
+++ b/src/components/curation/MechanismEvidence.vue
@@ -58,12 +58,12 @@ export default {
   <div class="row g-3 px-3 pt-3" v-if="isDisplayPublicationWarning">
     <p>
       <i class="bi bi-info-circle"></i> Please enter Publication(s) to provide
-      information on evidence.
+      information on functional studies.
     </p>
   </div>
   <div v-if="isDisplayEvidenceForm">
     <div class="row g-3 px-3 pt-3">
-      <h5>Evidence</h5>
+      <h5>Functional Studies</h5>
     </div>
     <div
       class="row g-3 px-3 py-3"

--- a/src/components/update-record/UpdateMechanism.vue
+++ b/src/components/update-record/UpdateMechanism.vue
@@ -475,7 +475,7 @@ export default {
                       <table class="table table-bordered mb-0">
                         <thead>
                           <tr>
-                            <th>Evidence Types</th>
+                            <th>Functional Studies</th>
                             <th>Publication</th>
                           </tr>
                         </thead>
@@ -518,7 +518,7 @@ export default {
                 </div>
               </div>
               <div v-if="isDisplayEvidenceForm">
-                <h5 class="mb-0">Evidence</h5>
+                <h5 class="mb-0">Functional Studies</h5>
                 <div
                   class="pt-3 pb-4"
                   v-for="pmid in Object.keys(mechanismEvidence)"
@@ -579,7 +579,7 @@ export default {
               </div>
               <p v-if="isDisplayPublicationWarning">
                 <i class="bi bi-info-circle"></i> Please add atleast 1
-                Publication to provide information on evidence.
+                Publication to provide information on functional studies.
               </p>
               <button
                 type="button"

--- a/src/views/AddLocusGeneDiseaseView.vue
+++ b/src/views/AddLocusGeneDiseaseView.vue
@@ -527,8 +527,8 @@ export default {
       </div>
     </div>
     <p v-if="!isGeneDataLoading && !geneData && !isDisplayGeneExistingData">
-      <i class="bi bi-info-circle"></i> Please enter Gene and click Search to
-      proceed further.
+      <i class="bi bi-info-circle"></i> Please enter Gene and click
+      <b>Search</b> to proceed further.
     </p>
     <div
       class="d-flex justify-content-center"

--- a/src/views/LocusGeneDiseaseView.vue
+++ b/src/views/LocusGeneDiseaseView.vue
@@ -659,7 +659,7 @@ export default {
                       <table class="table table-bordered mb-0">
                         <thead>
                           <tr>
-                            <th>Evidence Types</th>
+                            <th>Functional Studies</th>
                             <th>Publication</th>
                           </tr>
                         </thead>


### PR DESCRIPTION
Code change related to [G2P-494](https://www.ebi.ac.uk/panda/jira/browse/G2P-494). Rename mechanism 'Evidence' section to 'Functional Studies' and other minor change in info text.