### PR TITLE
G2P-405 Remove SO term in input label text of variant consequences

### DIFF
--- a/src/components/curation/VariantConsequences.vue
+++ b/src/components/curation/VariantConsequences.vue
@@ -26,8 +26,8 @@ export default {
     <div class="col-12">
       <h5>Variant Consequences<span class="text-danger">*</span></h5>
     </div>
-    <div class="col-12">
-      <table style="width: 70%" class="table table-bordered">
+    <div class="col-xl-6 col-12">
+      <table class="table table-bordered">
         <thead>
           <tr>
             <th style="width: 70%">
@@ -38,9 +38,19 @@ export default {
           </tr>
         </thead>
         <tbody>
-          <tr v-for="item in variantConsequencesAttribs">
+          <tr v-for="item in variantConsequencesAttribs" :key="item.inputKey">
             <td :class="getVariantConsequenceCssClass(item.hierarchyLevel)">
-              {{ item.labelText }}
+              <a
+                v-if="item.accession"
+                :href="`http://www.sequenceontology.org/browser/current_release/term/${item.accession}`"
+                style="text-decoration: none"
+                target="_blank"
+              >
+                {{ item.labelText }}
+              </a>
+              <span v-else>
+                {{ item.labelText }}
+              </span>
             </td>
             <td>
               <select

--- a/src/components/update-record/UpdateVariantConsequences.vue
+++ b/src/components/update-record/UpdateVariantConsequences.vue
@@ -144,8 +144,8 @@ export default {
               </div>
             </div>
             <div v-else>
-              <div class="col-12">
-                <table style="width: 70%" class="table table-bordered">
+              <div class="col-xl-6 col-12">
+                <table class="table table-bordered">
                   <thead>
                     <tr>
                       <th style="width: 70%">
@@ -165,7 +165,17 @@ export default {
                           getVariantConsequenceCssClass(item.hierarchyLevel)
                         "
                       >
-                        {{ item.labelText }}
+                        <a
+                          v-if="item.accession"
+                          :href="`http://www.sequenceontology.org/browser/current_release/term/${item.accession}`"
+                          style="text-decoration: none"
+                          target="_blank"
+                        >
+                          {{ item.labelText }}
+                        </a>
+                        <span v-else>
+                          {{ item.labelText }}
+                        </span>
                       </td>
                       <td>
                         <select

--- a/src/utility/CurationConstants.js
+++ b/src/utility/CurationConstants.js
@@ -135,34 +135,40 @@ export const VariantTypesAttribs = [
 
 export const VariantConsequencesAttribs = [
   {
-    labelText: "Altered_gene_product_level SO:0002314",
+    labelText: "Altered_gene_product_level",
     inputKey: "altered_gene_product_level",
     hierarchyLevel: 1,
+    accession: "SO:0002314",
   },
   {
-    labelText: "Decreased_gene_product_level SO:0002316",
+    labelText: "Decreased_gene_product_level",
     inputKey: "decreased_gene_product_level",
     hierarchyLevel: 2,
+    accession: "SO:0002316",
   },
   {
-    labelText: "Absent_gene_product SO:0002317",
+    labelText: "Absent_gene_product",
     inputKey: "absent_gene_product",
     hierarchyLevel: 3,
+    accession: "SO:0002317",
   },
   {
-    labelText: "Increased_gene_product_level SO:0002315",
+    labelText: "Increased_gene_product_level",
     inputKey: "increased_gene_product_level",
     hierarchyLevel: 2,
+    accession: "SO:0002315",
   },
   {
-    labelText: "Altered_gene_product_structure SO:0002318",
+    labelText: "Altered_gene_product_structure",
     inputKey: "altered_gene_product_structure",
     hierarchyLevel: 1,
+    accession: "SO:0002318",
   },
   {
     labelText: "Uncertain",
     inputKey: "uncertain",
     hierarchyLevel: 1,
+    accession: null,
   },
 ];
 


### PR DESCRIPTION
Code changes related to G2P-405. Remove SO term in input label text of variant consequences and add link to Sequence Ontology website.