### PR TITLE
Fix search display after API update

### DIFF
--- a/src/views/SearchPageView.vue
+++ b/src/views/SearchPageView.vue
@@ -196,14 +196,14 @@ export default {
             </tr>
           </thead>
           <tbody>
-            <tr v-for="item in searchData.results" :key="item.id">
+            <tr v-for="item in searchData.results" :key="item.stable_id">
               <td>
                 <router-link
-                  :to="`/lgd/${item.id}`"
-                  v-if="item.id"
+                  :to="`/lgd/${item.stable_id}`"
+                  v-if="item.stable_id"
                   style="text-decoration: none"
                 >
-                  {{ item.id }}
+                  {{ item.stable_id }}
                 </router-link>
               </td>
               <td>


### PR DESCRIPTION
The search API was updated to output the following format:
```
{
            "stable_id": "G2P01974",
            "gene": "CDH1",
            "genotype": "monoallelic_autosomal",
            "disease": "CDH1-related blepharo-cheiro-dontic syndrome",
            "mechanism": "undetermined",
            "panel": [
                "DD"
            ],
            "confidence": "definitive"
}
```

`id` was updated to `stable_id`