### PR TITLE
G2P-576 - Add public/private indicators to comment input labels

### DIFF
--- a/src/components/add-publication/UpdateMechanismEvidence.vue
+++ b/src/components/add-publication/UpdateMechanismEvidence.vue
@@ -471,7 +471,10 @@ export default {
                       :for="`evidence-type-input-${pmid}-description`"
                       class="form-label"
                     >
-                      Description
+                      Description (Private
+                      <ToolTip
+                        toolTipText="This description will only be visible to logged-in users"
+                      />)
                     </label>
                     <textarea
                       class="form-control"

--- a/src/components/add-publication/UpdatePhenotype.vue
+++ b/src/components/add-publication/UpdatePhenotype.vue
@@ -264,7 +264,7 @@ export default {
                     :for="`phenotype-summary-input-${pmid}`"
                     class="form-label"
                   >
-                    Summary
+                    Summary (Public)
                   </label>
                   <textarea
                     class="form-control"

--- a/src/components/add-publication/UpdatePublication.vue
+++ b/src/components/add-publication/UpdatePublication.vue
@@ -4,12 +4,14 @@ import {
   getFamiliesInputErrorMsg,
 } from "../../utility/CurationUtility.js";
 import { EUROPE_PMC_URL } from "../../utility/UrlConstants.js";
+import ToolTip from "../tooltip/ToolTip.vue";
 export default {
   props: {
     currentPublications: Object,
     publications: Object,
   },
   emits: ["update:publications"],
+  components: { ToolTip },
   data() {
     return {
       EUROPE_PMC_URL,
@@ -373,7 +375,10 @@ export default {
                           :for="`publication-comment-input-${pmid}`"
                           class="form-label"
                         >
-                          Comment
+                          Comment (Private
+                          <ToolTip
+                            toolTipText="This comment will only be visible to logged-in users"
+                          />)
                         </label>
                         <textarea
                           class="form-control"

--- a/src/components/add-publication/UpdateVariantTypes.vue
+++ b/src/components/add-publication/UpdateVariantTypes.vue
@@ -1,6 +1,7 @@
 <script>
 import { EUROPE_PMC_URL } from "../../utility/UrlConstants.js";
 import { VariantTypesAttribs } from "../../utility/CurationConstants.js";
+import ToolTip from "../tooltip/ToolTip.vue";
 export default {
   props: {
     publicationsData: Object,
@@ -8,6 +9,7 @@ export default {
     currentVariantTypes: Array,
   },
   emits: ["updateVariantTypes"],
+  components: { ToolTip },
   methods: {
     variantTypesSingleCheckboxHandler(
       primaryType,
@@ -180,7 +182,12 @@ export default {
             <th style="width: 10%">Inherited</th>
             <th style="width: 10%">Unknown Inheritance</th>
             <th style="width: 15%">Supporting Papers</th>
-            <th style="width: 35%">Comment</th>
+            <th style="width: 35%">
+              Comment (Private
+              <ToolTip
+                toolTipText="This comment will only be visible to logged-in users"
+              />)
+            </th>
           </tr>
         </thead>
         <tbody>

--- a/src/components/curation/ClinicalPhenotype.vue
+++ b/src/components/curation/ClinicalPhenotype.vue
@@ -173,7 +173,7 @@ export default {
                   :for="`phenotype-summary-input-${pmid}`"
                   class="form-label"
                 >
-                  Summary
+                  Summary (Public)
                 </label>
                 <textarea
                   class="form-control"

--- a/src/components/curation/Comment.vue
+++ b/src/components/curation/Comment.vue
@@ -1,16 +1,21 @@
 <script>
+import ToolTip from "../tooltip/ToolTip.vue";
 export default {
   props: {
     privateComment: String,
     publicComment: String,
   },
   emits: ["update:privateComment", "update:publicComment"],
+  components: { ToolTip },
 };
 </script>
 <template>
   <div class="py-3">
     <label for="private-comment-input" class="form-label">
-      Private comment
+      Comment (Private
+      <ToolTip
+        toolTipText="This comment will only be visible to logged-in users"
+      />)
     </label>
     <textarea
       class="form-control"
@@ -24,7 +29,7 @@ export default {
   </div>
   <div class="pb-3">
     <label for="public-comment-input" class="form-label">
-      Public comment
+      Comment (Public)
     </label>
     <textarea
       class="form-control"

--- a/src/components/curation/MechanismEvidence.vue
+++ b/src/components/curation/MechanismEvidence.vue
@@ -1,12 +1,14 @@
 <script>
 import { EvidenceTypesAttribs } from "../../utility/CurationConstants.js";
 import kebabCase from "lodash/kebabCase";
+import ToolTip from "../tooltip/ToolTip.vue";
 export default {
   props: {
     molecularMechanismSupport: String,
     mechanismEvidence: Object,
   },
   emits: ["updateMechanismEvidence"],
+  components: { ToolTip },
   methods: {
     mechanismEvidenceCheckboxHandler(key, pmid, checked, value) {
       let updatedMechanismEvidence = { ...this.mechanismEvidence };
@@ -134,7 +136,10 @@ export default {
           :for="`evidence-type-input-${pmid}-description`"
           class="form-label"
         >
-          Description
+          Description (Private
+          <ToolTip
+            toolTipText="This description will only be visible to logged-in users"
+          />)
         </label>
         <textarea
           class="form-control"

--- a/src/components/curation/Publication.vue
+++ b/src/components/curation/Publication.vue
@@ -4,6 +4,7 @@ import {
   getAffectedIndividualsInputErrorMsg,
   getFamiliesInputErrorMsg,
 } from "../../utility/CurationUtility.js";
+import ToolTip from "../tooltip/ToolTip.vue";
 export default {
   props: {
     fetchPublications: Function,
@@ -20,6 +21,7 @@ export default {
       EUROPE_PMC_URL,
     };
   },
+  components: { ToolTip },
   methods: {
     inputHandler(key, pmid, inputValue) {
       let updatedPublications = { ...this.publications };
@@ -349,7 +351,10 @@ export default {
                           :for="`publication-comment-input-${pmid}`"
                           class="form-label"
                         >
-                          Comment
+                          Comment (Private
+                          <ToolTip
+                            toolTipText="This comment will only be visible to logged-in users"
+                          />)
                         </label>
                         <textarea
                           class="form-control"

--- a/src/components/curation/VariantTypes.vue
+++ b/src/components/curation/VariantTypes.vue
@@ -1,11 +1,13 @@
 <script>
 import { VariantTypesAttribs } from "../../utility/CurationConstants.js";
+import ToolTip from "../tooltip/ToolTip.vue";
 export default {
   props: {
     publicationsData: Object,
     variantTypes: Object,
   },
   emits: ["updateVariantTypes"],
+  components: { ToolTip },
   methods: {
     variantTypesSingleCheckboxHandler(
       primaryType,
@@ -79,7 +81,12 @@ export default {
             <th style="width: 15%" v-if="isPublicationsDataAvailable">
               Supporting Papers
             </th>
-            <th style="width: 35%">Comment</th>
+            <th style="width: 35%">
+              Comment (Private
+              <ToolTip
+                toolTipText="This comment will only be visible to logged-in users"
+              />)
+            </th>
           </tr>
         </thead>
         <tbody>

--- a/src/components/update-record/AddComment.vue
+++ b/src/components/update-record/AddComment.vue
@@ -2,6 +2,7 @@
 import api from "../../services/api.js";
 import { ADD_COMMENT_URL } from "../../utility/UrlConstants.js";
 import { fetchAndLogApiResponseErrorMsg } from "../../utility/ErrorUtility.js";
+import ToolTip from "../tooltip/ToolTip.vue";
 
 export default {
   props: {
@@ -17,6 +18,7 @@ export default {
       addCommentSuccessMsg: null,
     };
   },
+  components: { ToolTip },
   methods: {
     addComment() {
       this.apiErrorMsg = this.addCommentSuccessMsg = null;
@@ -81,7 +83,10 @@ export default {
   <div v-else>
     <div class="pb-3">
       <label for="private-comment-input" class="form-label">
-        Private comment
+        Comment (Private
+        <ToolTip
+          toolTipText="This comment will only be visible to logged-in users"
+        />)
       </label>
       <textarea
         class="form-control"
@@ -94,7 +99,7 @@ export default {
     </div>
     <div class="pb-3">
       <label for="public-comment-input" class="form-label">
-        Public comment
+        Comment (Public)
       </label>
       <textarea
         class="form-control"

--- a/src/components/update-record/UpdateMechanism.vue
+++ b/src/components/update-record/UpdateMechanism.vue
@@ -592,7 +592,10 @@ export default {
                       :for="`evidence-type-input-${pmid}-description`"
                       class="form-label"
                     >
-                      Description
+                      Description (Private
+                      <ToolTip
+                        toolTipText="This description will only be visible to logged-in users"
+                      />)
                     </label>
                     <textarea
                       class="form-control"

--- a/src/components/update-record/UpdatePhenotype.vue
+++ b/src/components/update-record/UpdatePhenotype.vue
@@ -498,7 +498,7 @@ export default {
                       :for="`phenotype-summary-input-${pmid}`"
                       class="form-label"
                     >
-                      Summary
+                      Summary (Public)
                     </label>
                     <textarea
                       class="form-control"

--- a/src/components/update-record/UpdateVariantTypes.vue
+++ b/src/components/update-record/UpdateVariantTypes.vue
@@ -6,6 +6,7 @@ import {
 } from "../../utility/UrlConstants.js";
 import { fetchAndLogApiResponseErrorMsg } from "../../utility/ErrorUtility.js";
 import { VariantTypesAttribs } from "../../utility/CurationConstants.js";
+import ToolTip from "../tooltip/ToolTip.vue";
 
 export default {
   props: {
@@ -27,6 +28,7 @@ export default {
       EUROPE_PMC_URL,
     };
   },
+  components: { ToolTip },
   methods: {
     getInitialVariantTypes() {
       let variantTypesObj = {};
@@ -297,7 +299,12 @@ export default {
                       <th style="width: 10%">Inherited</th>
                       <th style="width: 10%">Unknown Inheritance</th>
                       <th style="width: 15%">Supporting Papers</th>
-                      <th style="width: 35%">Comment</th>
+                      <th style="width: 35%">
+                        Comment (Private
+                        <ToolTip
+                          toolTipText="This comment will only be visible to logged-in users"
+                        />)
+                      </th>
                     </tr>
                   </thead>
                   <tbody>


### PR DESCRIPTION
### Description

Add public/private indicators to comment input labels in Curation form, Update record page, and Add publications page.

---

### JIRA Ticket

[G2P-576](https://embl.atlassian.net/browse/G2P-576)

---

### Contributor Checklist

- [x] The code compiles and runs as expected
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, JIRA, etc.) has been updated as needed
- [x] The PR title includes the JIRA ticket number (if applicable) and a relevant title

---

### Reviewer Checklist

Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.

- [x] I have followed all review guidelines
