### PR TITLE
Update record page to display new format of publication comments

### DIFF
--- a/src/components/add-publication/UpdatePublication.vue
+++ b/src/components/add-publication/UpdatePublication.vue
@@ -120,11 +120,11 @@ export default {
                         </td>
                         <td class="ps-0">
                           <ul
-                            v-if="item.publication?.comments?.length > 0"
+                            v-if="item.comments?.length > 0"
                             class="mb-0"
                           >
                             <li
-                              v-for="commentItem in item.publication.comments"
+                              v-for="commentItem in item.comments"
                               :key="commentItem.comment"
                             >
                               {{ commentItem.comment }} ({{ commentItem.date }})

--- a/src/components/view-record/LocusGeneDiseaseDisplay.vue
+++ b/src/components/view-record/LocusGeneDiseaseDisplay.vue
@@ -943,12 +943,11 @@ export default {
                             </td>
                             <td v-if="isAuthenticated" class="ps-0">
                               <ul
-                                v-if="item.publication?.comments?.length > 0"
+                                v-if="item.comments?.length > 0"
                                 class="mb-0"
                               >
                                 <li
-                                  v-for="commentItem in item.publication
-                                    .comments"
+                                  v-for="commentItem in item.comments"
                                   :key="commentItem.comment"
                                 >
                                   {{ commentItem.comment }} ({{

--- a/src/utility/DownloadUtility.js
+++ b/src/utility/DownloadUtility.js
@@ -369,9 +369,9 @@ const preparePublicationsEvidenceObj = (
       // If user is authenticated, then include comment column data
       if (isAuthenticated) {
         bodyRow.push(
-          item.publication?.comments?.length > 0
+          item.comments?.length > 0
             ? {
-                ul: item.publication.comments.map(
+                ul: item.comments.map(
                   (commentItem) =>
                     `${commentItem.comment} (${commentItem.date})`
                 ),


### PR DESCRIPTION
### Description

The endpoint gene2phenotype/api/lgd/<str:stable_id>/ response format was updated to:
```
"publications": [
        {
            "publication": {
                "pmid": 2,
                "title": "Delineation of the intimate details of the backbone conformation of pyridine nucleotide coenzymes in aqueous solution.",
                "authors": "Bose KS, Sarma RH.",
                "year": "1975"
            },
            "number_of_families": 11,
            "consanguinity": "unknown",
            "affected_individuals": 11,
            "ancestry": null,
            "comments": [
                {
                    "comment": "PMID 2 has evidence for record CDH1",
                    "user": "diana_lemos",
                    "date": "2025-08-01"
                }
            ]
        }
]
```

This PR updates the record page to display the new format.
Related to https://github.com/EBI-G2P/gene2phenotype_api/pull/231

---

### JIRA Ticket

[G2P-569](https://embl.atlassian.net/browse/G2P-569)

---

### Contributor Checklist

- [x] The code compiles and runs as expected
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, JIRA, etc.) has been updated as needed
- [x] The PR title includes the JIRA ticket number (if applicable) and a relevant title

---

### Reviewer Checklist

Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.

- [ ] I have followed all review guidelines
