### PR TITLE
Update message to only display new_g2p_id if not null

### DIFF
--- a/src/views/LocusGeneDiseaseView.vue
+++ b/src/views/LocusGeneDiseaseView.vue
@@ -141,14 +141,15 @@ export default {
       <div>
         <i class="bi bi-info-circle"></i>
         {{ mergedDataMsg }} <br />
-        See the merged record here:
-        <router-link
-          v-if="mergedStableId"
-          :to="`/lgd/${mergedStableId}`"
-          class="fw-bold"
-        >
-          {{ mergedStableId }}
-        </router-link>
+        <template v-if="mergedStableId">
+          See the merged record here:
+          <router-link
+            :to="`/lgd/${mergedStableId}`"
+            class="fw-bold"
+          >
+            {{ mergedStableId }}
+          </router-link>
+        </template>
       </div>
     </div>
     <div v-if="locusGeneDiseaseData">

--- a/src/views/SearchPageView.vue
+++ b/src/views/SearchPageView.vue
@@ -189,14 +189,15 @@ export default {
       <div>
         <i class="bi bi-info-circle"></i>
         {{ mergedDataMsg }} <br />
-        See the merged record here:
-        <router-link
-          v-if="mergedStableId"
-          :to="`/lgd/${mergedStableId}`"
-          class="fw-bold"
-        >
-          {{ mergedStableId }}
-        </router-link>
+        <template v-if="mergedStableId">
+          See the merged record here:
+          <router-link
+            :to="`/lgd/${mergedStableId}`"
+            class="fw-bold"
+          >
+            {{ mergedStableId }}
+          </router-link>
+        </template>
       </div>
     </div>
     <div v-if="searchData">


### PR DESCRIPTION
### Description
The API was updated to display message if record has been deleted ([PR](https://github.com/EBI-G2P/gene2phenotype_api/pull/247))
This PR updated the message displayed on the website.

---

### JIRA Ticket
[G2P-589](https://embl.atlassian.net/browse/G2P-589)

---

### Contributor Checklist

- [x] The code compiles and runs as expected
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, JIRA, etc.) has been updated as needed
- [x] The PR title includes the JIRA ticket number (if applicable) and a relevant title

---

### Reviewer Checklist

Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.

- [ ] I have followed all review guidelines
