### PR TITLE
G2P 533, 622 - Don't display source for 'Uncertain' variant consequence and add link to ClinGen

### DIFF
--- a/src/components/view-record/LocusGeneDiseaseDisplay.vue
+++ b/src/components/view-record/LocusGeneDiseaseDisplay.vue
@@ -525,7 +525,11 @@ export default {
                               <span v-else>{{ item.variant_consequence }}</span>
                             </td>
                             <td>
-                              {{ item.support }}
+                              <template
+                                v-if="item.variant_consequence !== 'uncertain'"
+                              >
+                                {{ item.support }}
+                              </template>
                             </td>
                           </tr>
                         </tbody>

--- a/src/utility/DownloadUtility.js
+++ b/src/utility/DownloadUtility.js
@@ -190,7 +190,7 @@ const prepareVariantConsequencesObj = (locusGeneDiseaseData) => {
               SEQUENCE_ONTOLOGY_URL + item.accession
             )
           : item.variant_consequence,
-        item.support,
+        item.variant_consequence !== "uncertain" ? item.support : "",
       ]);
     // Prepare table rows (header and body rows)
     const variantConsequencesTableRows = [

--- a/src/utility/UrlConstants.js
+++ b/src/utility/UrlConstants.js
@@ -64,3 +64,4 @@ export const PANELAPP_URL =
   "https://panelapp.genomicsengland.co.uk/panels/entities/";
 export const GENCC_URL = "https://search.thegencc.org/genes/";
 export const UNIPROT_URL = "https://www.uniprot.org/uniprotkb/";
+export const CLINGEN_URL = "https://search.clinicalgenome.org/kb/genes/";

--- a/src/views/GeneView.vue
+++ b/src/views/GeneView.vue
@@ -10,6 +10,7 @@ import {
   DECIPHER_URL,
   ENSEMBL_GENE_URL,
   GENCC_URL,
+  CLINGEN_URL,
 } from "../utility/UrlConstants.js";
 import {
   CONFIDENCE_COLOR_MAP,
@@ -39,6 +40,7 @@ export default {
       OMIM_URL,
       PANELAPP_URL,
       UNIPROT_URL,
+      CLINGEN_URL,
       MARSH_PROBABILITY_THRESHOLD,
     };
   },
@@ -428,6 +430,16 @@ export default {
               target="_blank"
             >
               GenCC
+              <i class="bi bi-box-arrow-up-right"></i>
+            </a>
+          </li>
+          <li v-if="geneData.ids?.HGNC">
+            <a
+              :href="CLINGEN_URL + geneData.ids.HGNC"
+              style="text-decoration: none"
+              target="_blank"
+            >
+              ClinGen
               <i class="bi bi-box-arrow-up-right"></i>
             </a>
           </li>


### PR DESCRIPTION
### Description

This PR contains the following 2 changes:
1. In Record page and downloaded pdf, if Variant Consequence is 'uncertain' then do not display source.
2. Add link to ClinGen in gene page

---

### JIRA Ticket

1. [G2P-533](https://embl.atlassian.net/browse/G2P-533)
2. [G2P-622](https://embl.atlassian.net/browse/G2P-622)

---

### Contributor Checklist

- [x] The code compiles and runs as expected
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, JIRA, etc.) has been updated as needed
- [x] The PR title includes the JIRA ticket number (if applicable) and a relevant title

---

### Reviewer Checklist

Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.

- [ ] I have followed all review guidelines
