### PR TITLE
G2P 736 - Allow superusers to update mechanism and source values

### DIFF
--- a/src/components/add-publication/UpdateMechanismEvidence.vue
+++ b/src/components/add-publication/UpdateMechanismEvidence.vue
@@ -9,6 +9,8 @@ import {
 import kebabCase from "lodash/kebabCase";
 import { HELP_TEXT } from "../../utility/Constants.js";
 import { EUROPE_PMC_URL } from "../../utility/UrlConstants.js";
+import { useAuthStore } from "../../store/auth.js";
+import { mapState } from "pinia";
 export default {
   props: {
     currentMechanism: Object,
@@ -36,7 +38,7 @@ export default {
           updatedMechanismEvidence[pmid].evidence_types[key].indexOf(value);
         updatedMechanismEvidence[pmid].evidence_types[key].splice(
           indexToBeRemoved,
-          1
+          1,
         );
       }
       this.$emit("updateMechanismEvidence", updatedMechanismEvidence);
@@ -59,10 +61,17 @@ export default {
     };
   },
   computed: {
+    ...mapState(useAuthStore, ["isSuperUser"]),
     canUpdateMechanismInput() {
+      // Superusers can update mechanism regardless of currentMechanism.mechanism value
+      if (this.isSuperUser) return true;
+      // Non superusers can update mechanism only if currentMechanism.mechanism is "undetermined"
       return this.currentMechanism?.mechanism === "undetermined";
     },
     canUpdateMechanismSourceInput() {
+      // Superusers can update mechanism source regardless of currentMechanism.mechanism_support value
+      if (this.isSuperUser) return true;
+      // Non superusers can update mechanism source only if currentMechanism.mechanism_support is "inferred"
       return this.currentMechanism?.mechanism_support === "inferred";
     },
     isDisplayNewEvidenceForm() {
@@ -87,7 +96,7 @@ export default {
         this.molecularMechanismSupport === "evidence" &&
         this.molecularMechanism === "undetermined"
       ) {
-        return `Mechanism source can not be set to '${this.molecularMechanismSupport}' for 'undetermined' Mechanism`;
+        return "Mechanism source can not be set to 'evidence' for 'undetermined' Mechanism";
       }
       return null;
     },
@@ -174,7 +183,7 @@ export default {
                   @input="
                     $emit(
                       'update:molecularMechanismSupport',
-                      $event.target.value
+                      $event.target.value,
                     )
                   "
                   :disabled="!canUpdateMechanismSourceInput"
@@ -240,7 +249,7 @@ export default {
                   @input="
                     $emit(
                       'update:mechanismSynopsisSupport',
-                      $event.target.value
+                      $event.target.value,
                     )
                   "
                   aria-describedby="invalid-categorisation-input-source-feedback"
@@ -412,7 +421,7 @@ export default {
                                 class="form-check-input"
                                 type="checkbox"
                                 :id="`evidence-type-input-${pmid}-${kebabCase(
-                                  item.primaryType
+                                  item.primaryType,
                                 )}-${kebabCase(secondaryTypeItem)}`"
                                 :checked="
                                   mechanismEvidence[pmid].evidence_types[
@@ -424,14 +433,14 @@ export default {
                                     item.primaryType,
                                     pmid,
                                     $event.target.checked,
-                                    secondaryTypeItem
+                                    secondaryTypeItem,
                                   )
                                 "
                               />
                               <label
                                 class="form-check-label"
                                 :for="`evidence-type-input-${pmid}-${kebabCase(
-                                  item.primaryType
+                                  item.primaryType,
                                 )}-${kebabCase(secondaryTypeItem)}`"
                               >
                                 {{ secondaryTypeItem }}
@@ -445,7 +454,7 @@ export default {
                   <p
                     v-if="
                       Object.values(
-                        mechanismEvidence[pmid].evidence_types
+                        mechanismEvidence[pmid].evidence_types,
                       ).every((arr) => arr.length === 0) &&
                       mechanismEvidence[pmid].description.length === 0
                     "
@@ -457,7 +466,7 @@ export default {
                   <p
                     v-if="
                       Object.values(
-                        mechanismEvidence[pmid].evidence_types
+                        mechanismEvidence[pmid].evidence_types,
                       ).every((arr) => arr.length === 0) &&
                       mechanismEvidence[pmid].description.length > 0
                     "
@@ -486,7 +495,7 @@ export default {
                       "
                       :disabled="
                         Object.values(
-                          mechanismEvidence[pmid].evidence_types
+                          mechanismEvidence[pmid].evidence_types,
                         ).every((arr) => arr.length === 0)
                       "
                     >

--- a/src/components/update-record/UpdateMechanism.vue
+++ b/src/components/update-record/UpdateMechanism.vue
@@ -15,6 +15,8 @@ import ToolTip from "../tooltip/ToolTip.vue";
 import { fetchAndLogApiResponseErrorMsg } from "../../utility/ErrorUtility.js";
 import api from "../../services/api.js";
 import { HELP_TEXT } from "../../utility/Constants.js";
+import { useAuthStore } from "../../store/auth.js";
+import { mapState } from "pinia";
 
 export default {
   props: {
@@ -32,7 +34,7 @@ export default {
       mechanismSynopsis: "",
       mechanismSynopsisSupport: "",
       mechanismEvidence: this.getInitialMechanismEvidence(
-        this.currentPublications
+        this.currentPublications,
       ),
       isUpdateApiCallLoading: false,
       updateMechanismErrorMsg: null,
@@ -55,7 +57,7 @@ export default {
       api
         .patch(
           UPDATE_MECHANISM_URL.replace(":stableid", this.stableId),
-          requestBody
+          requestBody,
         )
         .then((response) => {
           this.isUpdateMechanismSuccess = true;
@@ -66,7 +68,7 @@ export default {
             error,
             error?.response?.data?.error,
             "Unable to update mechanism. Please try again later.",
-            "Unable to update mechanism."
+            "Unable to update mechanism.",
           );
         })
         .finally(() => {
@@ -99,11 +101,11 @@ export default {
       // convert mechanismEvidence from object to array of objects and include evidence that have non empty evidence types
       let mechanismEvidenceArray = [];
       for (const [publicationPmid, valueObj] of Object.entries(
-        this.mechanismEvidence
+        this.mechanismEvidence,
       )) {
         let evidenceTypesArray = [];
         for (const [primaryType, secondaryTypesArray] of Object.entries(
-          valueObj.evidence_types
+          valueObj.evidence_types,
         )) {
           if (secondaryTypesArray.length > 0) {
             let evidenceTypeObj = {
@@ -170,10 +172,17 @@ export default {
     kebabCase,
   },
   computed: {
+    ...mapState(useAuthStore, ["isSuperUser"]),
     canUpdateMechanismInput() {
+      // Superusers can update mechanism regardless of currentMechanism.mechanism value
+      if (this.isSuperUser) return true;
+      // Non superusers can update mechanism only if currentMechanism.mechanism is "undetermined"
       return this.currentMechanism?.mechanism === "undetermined";
     },
     canUpdateMechanismSourceInput() {
+      // Superusers can update mechanism source regardless of currentMechanism.mechanism_support value
+      if (this.isSuperUser) return true;
+      // Non superusers can update mechanism source only if currentMechanism.mechanism_support is "inferred"
       return this.currentMechanism?.mechanism_support === "inferred";
     },
     isDisplayEvidenceForm() {
@@ -198,7 +207,7 @@ export default {
         this.mechanismSupport === "evidence" &&
         this.mechanism === "undetermined"
       ) {
-        return `Mechanism source can not be set to '${this.mechanismSupport}' for 'undetermined' Mechanism`;
+        return "Mechanism source can not be set to 'evidence' for 'undetermined' Mechanism";
       }
       return null;
     },
@@ -543,7 +552,7 @@ export default {
                                 class="form-check-input"
                                 type="checkbox"
                                 :id="`evidence-type-input-${pmid}-${kebabCase(
-                                  item.primaryType
+                                  item.primaryType,
                                 )}-${kebabCase(secondaryTypeItem)}`"
                                 v-model="
                                   mechanismEvidence[pmid].evidence_types[
@@ -555,7 +564,7 @@ export default {
                               <label
                                 class="form-check-label"
                                 :for="`evidence-type-input-${pmid}-${kebabCase(
-                                  item.primaryType
+                                  item.primaryType,
                                 )}-${kebabCase(secondaryTypeItem)}`"
                               >
                                 {{ secondaryTypeItem }}
@@ -569,7 +578,7 @@ export default {
                   <p
                     v-if="
                       Object.values(
-                        mechanismEvidence[pmid].evidence_types
+                        mechanismEvidence[pmid].evidence_types,
                       ).every((arr) => arr.length === 0) &&
                       mechanismEvidence[pmid].description.length === 0
                     "
@@ -581,7 +590,7 @@ export default {
                   <p
                     v-if="
                       Object.values(
-                        mechanismEvidence[pmid].evidence_types
+                        mechanismEvidence[pmid].evidence_types,
                       ).every((arr) => arr.length === 0) &&
                       mechanismEvidence[pmid].description.length > 0
                     "
@@ -607,7 +616,7 @@ export default {
                       v-model="mechanismEvidence[pmid].description"
                       :disabled="
                         Object.values(
-                          mechanismEvidence[pmid].evidence_types
+                          mechanismEvidence[pmid].evidence_types,
                         ).every((arr) => arr.length === 0)
                       "
                     >


### PR DESCRIPTION
### Description

This PR contains the following 2 changes:
1. In update record page, allow superusers to update mechanism and source values regardless of current values
2. In add publications page, allow superusers to update mechanism and source values regardless of current values

API related PR - https://github.com/EBI-G2P/gene2phenotype_api/pull/373

---

### JIRA Ticket

[G2P-736](https://embl.atlassian.net/browse/G2P-736)

---

### Contributor Checklist

- [x] The code compiles and runs as expected
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, JIRA, etc.) has been updated as needed
- [x] The PR title includes the JIRA ticket number (if applicable) and a relevant title

---

### Reviewer Checklist

Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.

- [ ] I have followed all review guidelines
